### PR TITLE
fix(access): prevent premature role expiration

### DIFF
--- a/pkg/controllers/request_controller.go
+++ b/pkg/controllers/request_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/CTO2BPublic/passage-server/pkg/errors"
 	"github.com/CTO2BPublic/passage-server/pkg/models"
@@ -237,7 +238,7 @@ func (r *AccessRequestController) Approve(c *gin.Context) {
 	}
 
 	// Call role providers
-	err = r.callRoleProvidersAsync(ctx, providerMethodApprove, accessRequest, accessRole)
+	err = r.callRoleProvidersAsync(ctx, providerMethodApprove, accessRequest, accessRole, []string{})
 	// Partial success
 	if err != nil {
 		c.AbortWithStatusJSON(errors.AccessProviderCallPartiallyFailed(err))
@@ -273,7 +274,7 @@ func (r *AccessRequestController) Approve(c *gin.Context) {
 // @Param ID path string true "AccessRequest id" default(xxxx-xxxx-xxxx)
 func (r *AccessRequestController) Expire(c *gin.Context) {
 
-	ctx, span := tracing.NewSpanWrapper(c.Request.Context(), "controllers.RequestController.Expire")
+	ctx, span := tracing.NewSpanWrapper(c, "controllers.RequestController.Expire")
 	defer span.End()
 
 	id := c.Param("ID")
@@ -301,8 +302,26 @@ func (r *AccessRequestController) Expire(c *gin.Context) {
 		return
 	}
 
+	// Get all access requests for the user
+	userAccessRequests, err := Db.SelectAccessRequestsByUserID(ctx, accessRequest.Status.RequestedBy)
+	if err != nil {
+		c.AbortWithStatusJSON(errors.ErrorDatabaseSelect(err))
+		return
+	}
+
+	// Identify active roles from other approved requests
+	now := time.Now()
+	activeRoles := []string{}
+	for _, req := range userAccessRequests {
+		if req.Id != accessRequest.Id &&
+			req.Status.Status == models.AccessRequestApproved &&
+			req.Status.ExpiresAt.After(now) {
+			activeRoles = append(activeRoles, req.RoleRef.Name)
+		}
+	}
+
 	// Call role providers
-	err = r.callRoleProvidersAsync(ctx, providerMethodExpire, accessRequest, accessRole)
+	err = r.callRoleProvidersAsync(ctx, providerMethodExpire, accessRequest, accessRole, activeRoles)
 	if err != nil {
 		c.AbortWithStatusJSON(errors.AccessProviderCallPartiallyFailed(err))
 		return
@@ -332,7 +351,7 @@ const (
 	providerMethodExpire
 )
 
-func (r *AccessRequestController) callRoleProvidersAsync(ctx context.Context, method providerMethod, request *models.AccessRequest, role models.AccessRole) (err error) {
+func (r *AccessRequestController) callRoleProvidersAsync(ctx context.Context, method providerMethod, request *models.AccessRequest, role models.AccessRole, activeRoles []string) (err error) {
 
 	ctx, span := tracing.NewSpanWrapper(ctx, "controllers.RequestController.callRoleProviders")
 	defer span.End()
@@ -377,6 +396,17 @@ func (r *AccessRequestController) callRoleProvidersAsync(ctx context.Context, me
 					return
 				}
 			case providerMethodExpire:
+				// If the role is active in other requests, do not revoke it
+				for _, activeRole := range activeRoles {
+					if activeRole == role.Name {
+						log.Info().
+							Str("AccessRequest", request.Id).
+							Str("Role", role.Name).
+							Str("Provider", config.Name).
+							Msg("Skipping revocation for active role")
+						return
+					}
+				}
 				err := provider.RevokeAccess(ctx, request)
 				if err != nil {
 					_ = Event.AccessRequestExpireError(ctx, *request, config, err)

--- a/pkg/controllers/request_controller_test.go
+++ b/pkg/controllers/request_controller_test.go
@@ -1,0 +1,135 @@
+package controllers
+
+import (
+	"context"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/CTO2BPublic/passage-server/pkg/dbdriver"
+	"github.com/CTO2BPublic/passage-server/pkg/models"
+	"github.com/CTO2BPublic/passage-server/pkg/providers"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockProvider is a mock implementation of the Provider interface
+type mockProvider struct {
+	revokeCalled bool
+}
+
+func (m *mockProvider) GrantAccess(ctx context.Context, request *models.AccessRequest) error {
+	return nil
+}
+
+func (m *mockProvider) RevokeAccess(ctx context.Context, request *models.AccessRequest) error {
+	m.revokeCalled = true
+	return nil
+}
+
+func (m *mockProvider) ListUsersWithAccess(ctx context.Context, role models.AccessRoleRef) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) IsAccessExpired(ctx context.Context, request *models.AccessRequest) (bool, error) {
+	return false, nil
+}
+
+func setupHandlerTest(t *testing.T) (*gin.Context, *mockProvider, *dbdriver.Database) {
+
+	// Setup test database
+	dir, err := os.MkdirTemp("", "passage-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	Config.Db.Engine = "sqlite"
+	Config.Db.Sqlite.Filename = dir + "/test.db"
+	db := dbdriver.GetDriver()
+	db.Connect()
+	db.AutoMigrate()
+
+	// Create a mock provider
+	mockProv := &mockProvider{}
+	// Override the NewProvider function to return the mock provider
+	originalNewProvider := providers.NewProvider
+	providers.SetNewProviderFactory(func(ctx context.Context, providerConfig models.ProviderConfig) (providers.Provider, error) {
+		return mockProv, nil
+	})
+	t.Cleanup(func() {
+		providers.SetNewProviderFactory(originalNewProvider)
+	})
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	return c, mockProv, db
+}
+
+func TestExpireAccessRequest_WithActiveRoles(t *testing.T) {
+	c, mockProv, db := setupHandlerTest(t)
+
+	accessRequests := []models.AccessRequest{
+		{
+			Id:      "request1",
+			RoleRef: models.AccessRoleRef{Name: "test-role"},
+			Status: models.AccessRequestStatus{
+				RequestedBy: "test-user",
+				Status:      models.AccessRequestApproved,
+				ExpiresAt:   func() *time.Time { t := time.Now().Add(1 * time.Hour); return &t }(),
+				ProviderUsernames: map[string]string{
+					"mock": "username",
+				},
+			},
+		},
+		{
+			Id:      "request2",
+			RoleRef: models.AccessRoleRef{Name: "test-role"},
+			Status: models.AccessRequestStatus{
+				RequestedBy: "test-user",
+				Status:      models.AccessRequestApproved,
+				ExpiresAt:   func() *time.Time { t := time.Now().Add(1 * time.Hour); return &t }(),
+				ProviderUsernames: map[string]string{
+					"mock": "username",
+				},
+			},
+		},
+	}
+	for _, ar := range accessRequests {
+		err := db.InsertAccessRequest(context.Background(), ar)
+		require.NoError(t, err)
+	}
+
+	// Create a new controller with the mock database
+	controller := NewAccessRequestController()
+	controller.Roles = []models.AccessRole{
+		{
+			Name: "test-role",
+			Providers: []models.ProviderConfig{
+				{
+					Provider:   "mock",
+					Parameters: make(map[string]string),
+				},
+			},
+		},
+	}
+
+	// Create a test context
+	c.Set("uid", "test-user")
+	c.Set("utype", "token")
+	c.Params = gin.Params{gin.Param{Key: "ID", Value: "request1"}}
+
+	// Expire the first request
+	controller.Expire(c)
+
+	// Assert that RevokeAccess was not called
+	assert.False(t, mockProv.revokeCalled, "RevokeAccess should not have been called")
+
+	// Expire the second request
+	c.Params = gin.Params{gin.Param{Key: "ID", Value: "request2"}}
+	controller.Expire(c)
+
+	// Assert that RevokeAccess was called
+	assert.True(t, mockProv.revokeCalled, "RevokeAccess should have been called")
+}

--- a/pkg/dbdriver/access_request.go
+++ b/pkg/dbdriver/access_request.go
@@ -35,6 +35,12 @@ func (d *Database) SelectAccessRequests(ctx context.Context) (result []models.Ac
 	return result, q.Error
 }
 
+func (d *Database) SelectAccessRequestsByUserID(ctx context.Context, userID string) ([]models.AccessRequest, error) {
+	var result []models.AccessRequest
+	q := d.Engine.WithContext(ctx).Where("status_requested_by = ?", userID).Find(&result)
+	return result, q.Error
+}
+
 func (d *Database) AccessRequestExists(ctx context.Context, data models.AccessRequest) (bool, error) {
 	var count int64
 	err := d.Engine.WithContext(ctx).Model(&models.AccessRequest{}).Where("id = ?", data.Id).Count(&count).Error

--- a/pkg/dbdriver/setup.go
+++ b/pkg/dbdriver/setup.go
@@ -55,8 +55,11 @@ func (d *Database) Connect() {
 
 	// SQLite engine
 	if Config.Db.Engine == "sqlite" {
-
-		d.Engine, err = gorm.Open(sqlite.Open("gorm.db"), &gorm.Config{})
+		filename := "gorm.db"
+		if Config.Db.Sqlite.Filename != "" {
+			filename = Config.Db.Sqlite.Filename
+		}
+		d.Engine, err = gorm.Open(sqlite.Open(filename), &gorm.Config{})
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to connect to database")
 		}

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -23,7 +23,10 @@ type Provider interface {
 }
 
 func NewProvider(ctx context.Context, providerConfig models.ProviderConfig) (Provider, error) {
+	return newProviderFactory(ctx, providerConfig)
+}
 
+func newProvider(ctx context.Context, providerConfig models.ProviderConfig) (Provider, error) {
 	switch providerConfig.Provider {
 	case string(kinds.ProviderKindMock):
 		return mockp.NewMockProvider(ctx, providerConfig)
@@ -55,4 +58,14 @@ func NewProviderUsernames() models.ProviderUsernames {
 		p.ProviderUsernames[string(kind)] = ""
 	}
 	return p
+}
+
+// variable to allow overriding in tests
+var newProviderFactory = newProvider
+
+type ProviderFactoryFunc func(ctx context.Context, providerConfig models.ProviderConfig) (Provider, error)
+
+// SetNewProviderFactory allows overriding the provider factory function.
+func SetNewProviderFactory(f ProviderFactoryFunc) {
+	newProviderFactory = f
 }


### PR DESCRIPTION
When a user has multiple active access requests for the same role, expiring one of the requests would cause the role to be revoked, even though other active requests for the same role exist. This would prematurely remove the users permissions.

This commit fixes the bug by changing the expiration logic to:
1.  Fetch all active access requests for a user.
2.  Identify which roles should remain active.
3.  Only revoke access for roles that are no longer active across all requests.

A new test case has been added to verify that the fix works as expected and prevents this bug from reoccurring.